### PR TITLE
Feature / Conform InputFieldState to useful protocols

### DIFF
--- a/Sources/CleevioUI/Views/Inputs/FieldState.swift
+++ b/Sources/CleevioUI/Views/Inputs/FieldState.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public struct InputFieldState {
+public struct InputFieldState: Equatable, Hashable, Codable {
     public var isFocused: Bool
     public var isEnabled: Bool
     public var isError: Bool


### PR DESCRIPTION
It is useful for InputFieldState to conform to Equatable, so the state can be observed and compared. Added Hashable and Codable, as those protocols could be also useful.